### PR TITLE
add type name to the method links so that links to specific methods remain stable

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,5 @@
 # Unique header generation
-require './lib/unique_head.rb'
+require './lib/nesting_unique_head.rb'
 
 # Markdown
 set :markdown_engine, :redcarpet
@@ -12,7 +12,7 @@ set :markdown,
     tables: true,
     with_toc_data: true,
     no_intra_emphasis: true,
-    renderer: UniqueHeadCounter
+    renderer: NestingUniqueHeadCounter
 
 # Assets
 set :css_dir, 'stylesheets'

--- a/lib/nesting_unique_head.rb
+++ b/lib/nesting_unique_head.rb
@@ -12,7 +12,7 @@ class NestingUniqueHeadCounter < Middleman::Renderers::MiddlemanRedcarpetHTML
     @@headers_history[header_level] = text.parameterize
 
     if header_level > 1
-      for i in (header_level - 1).downto(1)
+      for i in (header_level - 1).downto(2)
         friendly_text.prepend("#{@@headers_history[i]}-") if @@headers_history.key?(i)
       end
     end


### PR DESCRIPTION
before methods would have the anchor of #get-10 and now they will have #patients-get